### PR TITLE
Make brightness use potion effect

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Brightness.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Brightness.java
@@ -1,7 +1,8 @@
 package me.zeroeightsix.kami.module.modules.render;
 
 import me.zeroeightsix.kami.module.Module;
-import me.zeroeightsix.kami.setting.Setting;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
 
 /**
  * Created by 086 on 12/12/2017.
@@ -9,25 +10,8 @@ import me.zeroeightsix.kami.setting.Setting;
 @Module.Info(name = "Brightness", description = "Makes everything brighter!", category = Module.Category.RENDER)
 public class Brightness extends Module {
 
-    @Setting(name = "Brightness")
-    public float brightness = 16;
-
-    @Setting(name = "prev_brightness", hidden = true)
-    public float prevBrightness = 1;
-
-    @Override
-    protected void onEnable() {
-        prevBrightness = mc.gameSettings.gammaSetting;
-    }
-
     @Override
     public void onUpdate() {
-        mc.gameSettings.gammaSetting = brightness;
+        mc.player.addPotionEffect(new PotionEffect(MobEffects.NIGHT_VISION, 1, 1));
     }
-
-    @Override
-    protected void onDisable() {
-        mc.gameSettings.gammaSetting = prevBrightness;
-    }
-
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Brightness.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Brightness.java
@@ -1,17 +1,14 @@
 package me.zeroeightsix.kami.module.modules.render;
 
+import me.zero.alpine.listener.EventHandler;
+import me.zero.alpine.listener.Listener;
 import me.zeroeightsix.kami.module.Module;
-import net.minecraft.init.MobEffects;
-import net.minecraft.potion.PotionEffect;
 
 /**
  * Created by 086 on 12/12/2017.
+ * @see me.zeroeightsix.kami.mixin.client.MixinEntityRenderer
  */
 @Module.Info(name = "Brightness", description = "Makes everything brighter!", category = Module.Category.RENDER)
 public class Brightness extends Module {
 
-    @Override
-    public void onUpdate() {
-        mc.player.addPotionEffect(new PotionEffect(MobEffects.NIGHT_VISION, 1, 1));
-    }
 }


### PR DESCRIPTION
From https://github.com/zeroeightysix/KAMI/issues/4 you wanted a better brightness this should work _almost_ perfectly, not sure what side effects this could bring.

Another alternative to doing this is settings the block brightness for each block in the world.