### PR TITLE
Add autobuild

### DIFF
--- a/autobuild
+++ b/autobuild
@@ -1,0 +1,1 @@
+./gradlew build

--- a/autobuild.bat
+++ b/autobuild.bat
@@ -1,0 +1,1 @@
+start gradlew.bat build


### PR DESCRIPTION
Saves you having to open a cmd prompt inside the folder and typing `gradlew.bat build` inside cmd every time you build.