### PR TITLE
Resolve issue #67

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,25 @@ repositories {
     mavenCentral()
 }
 
+/**
+ * Download a file from a URL (So we don't have to keep a local copy)
+ */
+def urlFile = { url, name ->
+    File file = new File("$buildDir/download/${name}.jar")
+    file.parentFile.mkdirs()
+    if (!file.exists()) {
+        new URL(url).withInputStream { downloadStream ->
+            file.withOutputStream { fileOut ->
+                fileOut << downloadStream
+            }
+        }
+    }
+    files(file.absolutePath)
+}
+
 dependencies {
     //mixin needs to be distributed with the mod, very important
-    compile("org.spongepowered:mixin:0.7.4-SNAPSHOT") {
+    compile("org.spongepowered:mixin:0.7.11-SNAPSHOT") {
         exclude module: 'launchwrapper'
         exclude module: 'guava'
         exclude module: 'gson'
@@ -67,7 +83,7 @@ dependencies {
     }
     compile "com.github.ZeroMemes:Alpine:1.5"
     compile group: 'net.jodah', name: 'typetools', version: '0.5.0'
-    compile 'com.github.cabaletta:baritone:v1.0.0-hotfix-2'
+    compile files(urlFile('https://github.com/cabaletta/baritone/releases/download/v1.0.0-hotfix-2/baritone-api-1.0.0-hotfix-2.jar', 'baritone'))
     compile(group: 'org.reflections', name: 'reflections', version: '0.9.11') {
         exclude group: 'com.google.guava', module: 'guava'
     }
@@ -102,7 +118,6 @@ shadowJar {
         include(dependency('net.jodah:typetools'))
         include(dependency('org.reflections:reflections'))
         include(dependency('org.javassist:javassist'))
-        include(dependency('com.github.cabaletta:baritone'))
     }
     exclude 'dummyThing'
     exclude 'LICENSE.txt'

--- a/src/main/java/me/zeroeightsix/kami/command/commands/PathCommand.java
+++ b/src/main/java/me/zeroeightsix/kami/command/commands/PathCommand.java
@@ -12,6 +12,9 @@ import java.awt.*;
 
 /**
  * Created by 086 on 25/01/2018.
+ *
+ * PLEASE READ: YOU WILL GET "CANNOT RESOLVE SYMBOL" ERRORS IN THIS CLASS. THIS IS OK.
+ * THIS IS NORMAL. IT WILL STILL COMPILE. DO NOT WORRY ABOUT IT. PLS AND THANK <3
  */
 public class PathCommand extends Command {
     public PathCommand() {

--- a/src/main/java/me/zeroeightsix/kami/setting/SettingsClass.java
+++ b/src/main/java/me/zeroeightsix/kami/setting/SettingsClass.java
@@ -165,7 +165,7 @@ public class SettingsClass {
             if (primitiveType == null)
                 throw new RuntimeException("Unsupported value: " + value.getClass().getSimpleName());
             try {
-                value = value.getClass().getDeclaredMethod(fieldType.getName() + "Value", null).invoke(value);
+                value = value.getClass().getDeclaredMethod(fieldType.getName() + "Value", (Class<?>[]) null).invoke(value);
 
                 field.set(holder, value);
             } catch (Exception e) {


### PR DESCRIPTION
This is a workaround for the baritone crash when you import it from github. Grabbing the library from GitHub directly via it's download URL seems to fix the problem, however in order to access methods such as .mine() which takes a `Block`, you have to use Reflection to avoid compiler errors. 

Until Baritone fixes this problem, not much can be done (at least from what I've tried, I spent 5 hours trying to fix it).