### PR TITLE
Gh actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Gradle CI
 
 on: [push]
 
@@ -15,3 +15,5 @@ jobs:
         java-version: 1.8
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,4 +16,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@master
+      with:
+        name: KAMI-*-release.jar
+        path: /home/runner/work/KAMI/KAMI/build/libs/

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Gill Bates
+name: Java CI
 
 on: [push]
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Gradle CI
+name: Gill Bates
 
 on: [push]
 
@@ -18,5 +18,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@master
       with:
-        name: KAMI-*-release.jar
+        name: KAMI-b9-release.jar
         path: /home/runner/work/KAMI/KAMI/build/libs/


### PR DESCRIPTION
Added a CI Pipeline based on new Actions feature that runs a gradle build on incoming push.  

It does not seem like the the actual CI job is accessable publicly.  
The artifact [download link](https://github.com/blockparole/KAMI/suites/292496000/artifacts/228459) on the other hand is useable without further repo permissions needed, but it has to be published in some form because the links isnt publicly available.

![action webui screenshot](https://i.imgur.com/npE0wP0.png)