### PR TITLE
CAura canplace entity check boost2

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/CrystalAura.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/CrystalAura.java
@@ -232,14 +232,12 @@ public class CrystalAura extends Module {
     private boolean canPlaceCrystal(BlockPos blockPos) {
         BlockPos boost = blockPos.add(0, 1, 0);
         BlockPos boost2 = blockPos.add(0, 2, 0);
-        if ((mc.world.getBlockState(blockPos).getBlock() != Blocks.BEDROCK
-                && mc.world.getBlockState(blockPos).getBlock() != Blocks.OBSIDIAN)
-                || mc.world.getBlockState(boost).getBlock() != Blocks.AIR
-                || mc.world.getBlockState(boost2).getBlock() != Blocks.AIR
-                || !mc.world.getEntitiesWithinAABB(Entity.class, new AxisAlignedBB(boost)).isEmpty()) {
-            return false;
-        }
-        return true;
+        return (mc.world.getBlockState(blockPos).getBlock() == Blocks.BEDROCK
+                || mc.world.getBlockState(blockPos).getBlock() == Blocks.OBSIDIAN)
+                && mc.world.getBlockState(boost).getBlock() == Blocks.AIR
+                && mc.world.getBlockState(boost2).getBlock() == Blocks.AIR
+                && mc.world.getEntitiesWithinAABB(Entity.class, new AxisAlignedBB(boost)).isEmpty()
+                && mc.world.getEntitiesWithinAABB(Entity.class, new AxisAlignedBB(boost2)).isEmpty();
     }
 
     public static BlockPos getPlayerPos() {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/CrystalAura.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/CrystalAura.java
@@ -39,7 +39,7 @@ import static me.zeroeightsix.kami.util.EntityUtil.calculateLookAt;
 
 /**
  * Created by 086 on 28/12/2017.
- * Last Updated 29 June 2019 by hub
+ * Updated 3 December 2019 by hub
  */
 @Module.Info(name = "CrystalAura", category = Module.Category.COMBAT)
 public class CrystalAura extends Module {


### PR DESCRIPTION
This fixes a bug by adding a check to the canPlaceCrystal method to check  for entities at boost2.

Previous behaviour:
![](https://i.imgur.com/O2tvIjW.png)
