### PR TITLE
Prevent rendering issues with Freecam in walls (Should fix KAMI#168) …

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinEntityRenderer.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinEntityRenderer.java
@@ -8,6 +8,7 @@ import me.zeroeightsix.kami.module.modules.render.Brightness;
 import me.zeroeightsix.kami.module.modules.render.NoHurtCam;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.EntityRenderer;
@@ -78,6 +79,15 @@ public class MixinEntityRenderer {
             return new ArrayList<>();
         else
             return worldClient.getEntitiesInAABBexcluding(entityIn, boundingBox, predicate);
+    }
+
+    @Redirect(method = "renderWorldPass", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/AbstractClientPlayer;isSpectator()Z"))
+    public boolean noclipIsSpectator(AbstractClientPlayer acp) {
+        // [WebringOfTheDamned]
+        // Freecam doesn't actually use spectator mode, but it can go through walls, and only spectator mode is "allowed to" go through walls as far as the renderer is concerned
+        if (ModuleManager.isModuleEnabled("Freecam"))
+            return true;
+        return acp.isSpectator();
     }
 
 }

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinFrustum.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinFrustum.java
@@ -1,0 +1,26 @@
+package me.zeroeightsix.kami.mixin.client;
+
+import me.zeroeightsix.kami.module.ModuleManager;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.client.renderer.culling.Frustum;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Created by 20kdc on 14/02/2020.
+ */
+@Mixin(Frustum.class)
+public abstract class MixinFrustum {
+
+    @Inject(method = "Lnet/minecraft/client/renderer/culling/Frustum;isBoundingBoxInFrustum(Lnet/minecraft/util/math/AxisAlignedBB;)Z", at = @At("HEAD"), cancellable = true)
+    public void isBoundingBoxEtc(AxisAlignedBB ignore, CallbackInfoReturnable<Boolean> info) {
+        // [WebringOfTheDamned]
+        // This is used because honestly the Mojang frustrum bounding box thing is a mess.
+        // This & MixinEntityRenderer get it working on OptiFine, but MixinVisGraph is necessary on Vanilla.
+        if (ModuleManager.isModuleEnabled("Freecam"))
+            info.setReturnValue(true);
+    }
+
+}

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinRenderGlobal.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinRenderGlobal.java
@@ -1,14 +1,22 @@
 package me.zeroeightsix.kami.mixin.client;
 
+import java.util.Deque;
+import me.zeroeightsix.kami.module.ModuleManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ChunkRenderContainer;
 import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.client.renderer.chunk.RenderChunk;
+import net.minecraft.client.renderer.ViewFrustum;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.BlockRenderLayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Created by 086 on 11/04/2018.
@@ -19,9 +27,9 @@ public class MixinRenderGlobal {
     @Shadow Minecraft mc;
     @Shadow public ChunkRenderContainer renderContainer;
 
-    @Inject(method = "renderBlockLayer(Lnet/minecraft/util/BlockRenderLayer;)V", at = @At("HEAD"), cancellable = true)
-    public void renderBlockLayer(BlockRenderLayer blockLayerIn, CallbackInfo callbackInfo) {
-        callbackInfo.cancel();
+//    @Inject(method = "renderBlockLayer(Lnet/minecraft/util/BlockRenderLayer;)V", at = @At("HEAD"), cancellable = true)
+//    public void renderBlockLayer(BlockRenderLayer blockLayerIn, CallbackInfo callbackInfo) {
+//        callbackInfo.cancel();
 
 //        this.mc.entityRenderer.enableLightmap();
 //
@@ -63,6 +71,6 @@ public class MixinRenderGlobal {
 //        }
 //
 //        this.mc.entityRenderer.disableLightmap();
-    }
+//    }
 
 }

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinVisGraph.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinVisGraph.java
@@ -1,0 +1,30 @@
+package me.zeroeightsix.kami.mixin.client;
+
+import java.util.EnumSet;
+import java.util.Set;
+import net.minecraft.client.renderer.chunk.VisGraph;
+import net.minecraft.util.EnumFacing;
+import me.zeroeightsix.kami.module.ModuleManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Created by 20kdc on 14/02/2020, but really 15/02/2020 because this is basically being recycled
+ */
+@Mixin(VisGraph.class)
+public class MixinVisGraph {
+
+    @Inject(method = "getVisibleFacings", at = @At("HEAD"), cancellable = true)
+    public void getVisibleFacings(CallbackInfoReturnable<Set<EnumFacing>> callbackInfo) {
+        // WebringOfTheDamned
+        // This part prevents the "block-level culling". OptiFine does this for you but vanilla doesn't.
+        // We have to implement this here or else OptiFine causes trouble.
+        if (ModuleManager.isModuleEnabled("Freecam"))
+            callbackInfo.setReturnValue(EnumSet.<EnumFacing>allOf(EnumFacing.class));
+    }
+
+}

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/Freecam.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/Freecam.java
@@ -54,6 +54,10 @@ public class Freecam extends Module {
             mc.player.capabilities.isFlying = true;
             mc.player.capabilities.setFlySpeed(speed.getValue() / 100f);
             mc.player.noClip = true;
+            // WebringOfTheDamned
+            // This is needed for some reason, as is the converse in onDisable.
+            mc.renderChunksMany = false;
+            mc.renderGlobal.loadRenderers();
         }
     }
 
@@ -74,6 +78,10 @@ public class Freecam extends Module {
             if (isRidingEntity) {
                 mc.player.startRiding(ridingEntity, true);
             }
+            // WebringOfTheDamned
+            // This is needed for some reason, as is the converse in onEnable.
+            mc.renderChunksMany = true;
+            mc.renderGlobal.loadRenderers();
         }
     }
 

--- a/src/main/resources/kami_at.cfg
+++ b/src/main/resources/kami_at.cfg
@@ -7,6 +7,7 @@ public net.minecraft.world.chunk.storage.ExtendedBlockStorage * # All fields
 public net.minecraft.world.chunk.Chunk * # All fields
 public net.minecraft.client.renderer.RenderGlobal * # All fields
 public net.minecraft.client.renderer.RenderGlobal *() # All methods
+public net.minecraft.client.renderer.ViewFrustum *() # All fields
 public net.minecraft.world.chunk.BlockStateContainer * # All fields
 public net.minecraft.client.renderer.EntityRenderer * # All fields
 public net.minecraft.client.renderer.EntityRenderer *() # All methods

--- a/src/main/resources/mixins.kami.json
+++ b/src/main/resources/mixins.kami.json
@@ -22,6 +22,8 @@
     "MixinNetHandlerPlayClient",
     "MixinRenderLiving",
     "MixinPlayerControllerMP",
-    "MixinEntityLlama"
+    "MixinEntityLlama",
+    "MixinFrustum",
+    "MixinVisGraph"
   ]
 }


### PR DESCRIPTION
Fixed version of description that does not, hopefully, reflect my current state:

This should fix #168.
The method for doing so is best described as "The stuff that works for OptiFine clients" followed by "The workaround for non-OptiFine clients".
These are as follows:
1. Spectator mode manages to avoid a lot of the problems, so the flag is turned on in Freecam.
2. The Mojang method of detecting Frustum/bounding boxes collisions either doesn't work or somehow reasonably reliably generates a pattern of chunks which doesn't properly 'spread'. Either way, if Freecam is on, pretend the check always succeeds.

The workaround for non-OptiFine clients is in turn best described as what OptiFine is doing different: OptiFine removes the optimization where the current block you're in is used as a reference for culling. I can't mixin RenderGlobal without breaking OptiFine support, but I can mixin the function it calls, so I did that.