### PR TITLE
Make string settings .set commands not act weird

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/setting/impl/StringSetting.java
+++ b/src/main/java/me/zeroeightsix/kami/setting/impl/StringSetting.java
@@ -22,4 +22,13 @@ public class StringSetting extends Setting<String> {
         return converter;
     }
 
+    @Override
+    public String getValueAsString() {
+        return getValue();
+    }
+
+    @Override
+    public void setValueFromString(String s) {
+        setValue(s);
+    }
 }


### PR DESCRIPTION
Not sure if there's an issue this fixes, but if there is, it'd go like this:

`.set SomeModule SomeStringSetting "Blah blah blah"` fails

`.set SomeModule SomeStringSetting "'Blah blah blah'"` works, but it shouldn't need the extra quotes

I noticed this during the development of the XRay PR.
This even being a thing is an oversight on my part last time I went near the settings code, and this PR resolves that.
The fix is simple, since getValueAsString/setValueFromString are specifically for this kind of command-line specific behavior.