### PR TITLE
Fixed Formatting Regex

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/command/Command.java
+++ b/src/main/java/me/zeroeightsix/kami/command/Command.java
@@ -68,7 +68,7 @@ public abstract class Command {
 		
 		public ChatMessage(String text) {
 			
-			Pattern p = Pattern.compile("&[0123456789abcdefrlosmk]");
+			Pattern p = Pattern.compile("&[0123456789abcdefrlonmk]");
 			Matcher m = p.matcher(text);
 			StringBuffer sb = new StringBuffer();
 


### PR DESCRIPTION
According to https://www.digminecraft.com/lists/color_list_pc.php "s" is not a valid formatting character. On top of that the formatting character "n" (Underline) was missing. This pull request removes the "s" from and adds the "n" to the regex.