### PR TITLE
Added Macros

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/KamiMod.java
+++ b/src/main/java/me/zeroeightsix/kami/KamiMod.java
@@ -5,6 +5,7 @@ import me.zero.alpine.EventManager;
 import me.zeroeightsix.kami.feature.AbstractFeature;
 import me.zeroeightsix.kami.feature.FeatureManager;
 import me.zeroeightsix.kami.feature.Listening;
+import me.zeroeightsix.kami.feature.MacroManager;
 import me.zeroeightsix.kami.feature.command.Command;
 import me.zeroeightsix.kami.setting.SettingsRegister;
 import me.zeroeightsix.kami.setting.config.Configuration;
@@ -64,6 +65,8 @@ public class KamiMod implements ModInitializer {
         SettingsRegister.register("commandPrefix", Command.commandPrefix);
         loadConfiguration();
         KamiMod.log.info("Settings loaded");
+
+        MacroManager.INSTANCE.registerMacros();
 
         // After settings loaded, we want to let the enabled modules know they've been enabled (since the setting is done through reflection)
         FeatureManager.INSTANCE.getFeatures().stream().filter(AbstractFeature::isEnabled).forEach(AbstractFeature::enable);

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraftClient.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraftClient.java
@@ -3,6 +3,7 @@ package me.zeroeightsix.kami.mixin.client;
 import me.zeroeightsix.kami.KamiMod;
 import me.zeroeightsix.kami.event.events.ScreenEvent;
 import me.zeroeightsix.kami.event.events.TickEvent;
+import me.zeroeightsix.kami.feature.MacroManager;
 import me.zeroeightsix.kami.util.Wrapper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
@@ -62,6 +63,7 @@ public class MixinMinecraftClient {
     private void save() {
         System.out.println("Shutting down: saving KAMI configuration");
         KamiMod.saveConfiguration();
+        MacroManager.INSTANCE.saveMacros();
         System.out.println("Configuration saved.");
     }
 

--- a/src/main/java/me/zeroeightsix/kami/util/Macro.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/Macro.kt
@@ -1,0 +1,64 @@
+package me.zeroeightsix.kami.util
+
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import me.zeroeightsix.kami.KamiMod
+import me.zeroeightsix.kami.feature.command.Command
+import java.io.*
+import java.util.*
+
+/**
+ * @author dominikaaaa
+ * Created by dominikaaaa on 04/05/20
+ */
+object Macro {
+    private val gson = GsonBuilder().setPrettyPrinting().create()
+    private const val configName = "KAMIMacros.json"
+    private val file = File(configName)
+
+    fun writeMemoryToFile() {
+        try {
+            val fw = FileWriter(file, false)
+            gson.toJson(Macros.macros, fw)
+            fw.flush()
+            fw.close()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    fun readFileToMemory() {
+        try {
+            Macros.macros = gson.fromJson(FileReader(file), object : TypeToken<HashMap<Int?, List<String?>?>?>() {}.type)
+        } catch (e: FileNotFoundException) {
+            KamiMod.log.warn("Could not find file $configName, clearing the macros list")
+            Macros.macros.clear()
+        }
+    }
+
+    fun getMacrosForKey(keycode: Int): List<String?>? {
+        for ((key, value) in Macros.macros) {
+            if (keycode == key.toInt()) {
+                return value
+            }
+        }
+        return null
+    }
+
+    fun addMacroToKey(keycode: Int?, macro: String?) {
+        if (macro == null) return  // prevent trying to add a null macro
+        Macros.macros.getOrPut(keycode, ::mutableListOf).add(macro)
+    }
+
+    fun removeMacro(keycode: Int) {
+        for (entry in Macros.macros.entries) {
+            if (entry.key == keycode) {
+                entry.setValue(null)
+            }
+        }
+    }
+
+    fun sendMacrosToChat(messages: Array<String?>) { // TODO: this is deprecated, use sendFeedback instead
+        for (s in messages) Command.sendChatMessage("[$s]")
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/util/Macros.java
+++ b/src/main/java/me/zeroeightsix/kami/util/Macros.java
@@ -1,0 +1,19 @@
+package me.zeroeightsix.kami.util;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author dominikaaaa
+ * Lazy fix used for Java instance of {@link me.zeroeightsix.kami.util.Macro} and {@link me.zeroeightsix.kami.feature.MacroManager}
+ * TODO: Port this to Kotlin. I had issues looping through a Java Map in Kotlin, like so:
+ *       for ((key1, value) in Macros.macros) {
+ */
+public class Macros {
+    /*
+     * Map of all the macros.
+     * KeyCode, Actions
+     */
+    public static Map<Integer, List<String>> macros = new LinkedHashMap<>();
+}

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/MacroManager.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/MacroManager.kt
@@ -1,0 +1,59 @@
+package me.zeroeightsix.kami.feature
+
+import me.zeroeightsix.kami.KamiMod
+import me.zeroeightsix.kami.feature.command.Command
+import me.zeroeightsix.kami.util.Macro
+import me.zeroeightsix.kami.util.Wrapper
+import net.minecraft.server.network.packet.ChatMessageC2SPacket
+
+/**
+ * @author dominikaaaa
+ * Created by dominikaaaa on 04/05/20
+ */
+object MacroManager {
+
+    /**
+     * Reads macros from KAMIMacros.json into the macros Map
+     */
+    fun registerMacros() {
+        KamiMod.log.info("Registering macros...")
+        Macro.readFileToMemory()
+        KamiMod.log.info("Macros registered")
+    }
+
+    /**
+     * Saves macros from the macros Map into KAMIMacros.json
+     */
+    fun saveMacros() {
+        KamiMod.log.info("Saving macros...")
+        Macro.writeMemoryToFile()
+        KamiMod.log.info("Macros saved")
+    }
+
+    /**
+     * Sends the message or command, depending on which one it is
+     * @param keycode Int keycode of the key the was pressed
+     */
+    fun sendMacro(keycode: Int) {
+        val macrosForThisKey = Macro.getMacrosForKey(keycode) ?: return
+        for (currentMacro in macrosForThisKey) {
+            if (currentMacro!!.startsWith(Command.getCommandPrefix())) { // this is done instead of just sending a chat packet so it doesn't add to the chat history
+//                MessageSendHelper.sendKamiCommand(currentMacro, false) // ie, the 'false' here
+                // TODO: I can't figure out how
+            } else {
+                sendServerMessage(currentMacro)
+            }
+        }
+    }
+
+    /**
+     * Helper for sending a literal chat packet. You might want to convert this to a util or something you can reuse.
+     */
+    private fun sendServerMessage(message: String) {
+        if (Wrapper.getMinecraft().player != null) {
+            Wrapper.getPlayer().networkHandler.sendPacket(ChatMessageC2SPacket(message))
+        } else {
+            KamiMod.log.warn("Could not send server message: \"$message\"")
+        }
+    }
+}

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/MacroCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/MacroCommand.kt
@@ -1,0 +1,95 @@
+package me.zeroeightsix.kami.feature.command
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.builder.RequiredArgumentBuilder
+import net.minecraft.server.command.CommandSource
+
+/**
+ * @author dominikaaaa
+ * Created by dominikaaaa on 04/05/20
+ */
+class MacroCommand : Command() {
+    override fun register(dispatcher: CommandDispatcher<CommandSource>) {
+        dispatcher.register(
+            LiteralArgumentBuilder.literal<CommandSource>("macro")
+                .then(
+                    RequiredArgumentBuilder.argument<CommandSource, String>(
+                        "key|list",
+                        StringArgumentType.string()
+                    )
+                            /* TODO: port the rest of the command to the new command system?
+                                     This is where I get completely lost, as I can't figure out how executes really works
+                        .executes { context: CommandContext<CommandSource> ->
+                            val m =
+                                context.getArgument(
+                                    "list",
+                                    Module::class.java
+                                )
+
+                        }
+                             */
+                )
+        )
+    }
+
+}
+/*
+class MacroCommand : Command("macro", ChunkBuilder().append("key|list").append("clear|message/command").build(), "m") {
+    override fun call(args: Array<out String?>) {
+        val rKey = args[0]
+        val macro = args[1]
+        val key = Wrapper.getKey(rKey)
+
+        if (key == 0 && !rKey.equals("list", true)) {
+            sendErrorMessage("Unknown key '&7$rKey&f'! Left alt is &7lmenu&f and left Control is &7lctrl&f. You cannot bind the &7meta&f key.")
+            return
+        }
+
+        val keyList: List<String?>? = Macro.getMacrosForKey(key)
+
+        when {
+            args[0] == null -> { /* key, error message is caught by the command handler but you don't want to continue the rest */
+                return
+            }
+            args[0] == "list" -> {
+                if (Macros.macros.isEmpty()) {
+                    sendChatMessage("You have no macros")
+                    return
+                }
+                sendChatMessage("You have the following macros: ")
+                for ((key1, value) in Macros.macros) {
+                    sendRawChatMessage(Wrapper.getKeyName(key1) + ": $value")
+                }
+                return
+            }
+            args[1] == null -> { /* message */
+                if (keyList == null || keyList.isEmpty()) {
+                    sendChatMessage("'&7$rKey&f' has no macros")
+                    return
+                }
+                sendChatMessage("'&7$rKey&f' has the following macros: ")
+                Macro.sendMacrosToChat(keyList.toTypedArray())
+                return
+            }
+            args[1] == "clear" -> {
+                Macro.removeMacro(key)
+                MacroManager.saveMacros()
+                MacroManager.registerMacros()
+                sendChatMessage("Cleared macros for '&7$rKey&f'")
+                return
+            }
+            args[2] != null -> { /* some random 3rd argument which shouldn't exist */
+                sendWarningMessage("$chatLabel Your macro / command must be inside quotes, as 1 argument in the command. Example: &7" + getCommandPrefix() + label + " R \";set AutoSpawner debug toggle\"")
+                return
+            }
+            else -> {
+                Macro.addMacroToKey(key, macro)
+                MacroManager.saveMacros()
+                sendChatMessage("Added macro '&7$macro&f' for key '&7$rKey&f'")
+            }
+        }
+    }
+}
+ */


### PR DESCRIPTION
Redo of #190

Some things to consider
- [ ] You might want to switch over the deprecated sendChatMessage to sendFeedback, as I couldn't figure that one out
- [ ] You'll want to convert sendServerMessage to a proper util or however you're managing chat stuff
- [ ] The Macros class should be ported to MacroManager, but I had an issue with looping through Kotlin Maps in Kotlin, so you should see the comment inside it. Once this is fixed, I'd love to see how that works as well (:
- [ ] The command, for the most part, isn't ported, as the new command system is really confusing to me :sweat_smile: (maybe one day I'll get around to properly understanding it?)
- [ ] I added saving and registering of macros to MixinMinecraft and KamiMod, respectively, and they are also reloaded when adding new ones, so that should all be fine.  
- [ ] This should close issue #95, while not strictly macros, I saw you noticed my idea there :p
- [ ] One last thing, you'll need to call sendMacro() wherever you do binds, which we talked about in dms 
- [ ] Line 42 in MacroManager.kt is supposed to be "I can't figure out how to send KAMI commands in the fabric branch", but I evidently pushed before I finished writing that one :p
