### PR TITLE
[bump] KAMI to `nov` and Fabric mod to `1.16.4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## A Minecraft utility mod for anarchy servers.
 
-The Fabric 1.16.3 version is in active development.
+The Fabric 1.16.4 version is in active development.
 
 ## Preview
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 # Fabric
 minecraft_version=1.16.4
 yarn_mappings=1.16.4+build.1:v2
-loader_version=0.10.6+build.214
+loader_version=0.9.3+build.207
 loom_version=0.5-SNAPSHOT
 # KAMI
 mod_version=nov

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx3G
 # Fabric
-minecraft_version=1.16.3
-yarn_mappings=1.16.3+build.7
-loader_version=0.9.3+build.207
-loom_version=0.4-SNAPSHOT
+minecraft_version=1.16.4
+yarn_mappings=1.16.4+build.1:v2
+loader_version=0.10.6+build.214
+loom_version=0.5-SNAPSHOT
 # KAMI
-mod_version=oct
+mod_version=nov
 maven_group=me.zeroeightsix
 archives_base_name=kami
 # Dependencies

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinChatScreen.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinChatScreen.java
@@ -11,7 +11,7 @@ import me.zeroeightsix.kami.gui.windows.Settings;
 import me.zeroeightsix.kami.util.Wrapper;
 import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.server.command.CommandSource;
+import net.minecraft.command.CommandSource;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinCommandSuggestor.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinCommandSuggestor.java
@@ -9,7 +9,7 @@ import me.zeroeightsix.kami.gui.windows.Settings;
 import me.zeroeightsix.kami.util.Wrapper;
 import net.minecraft.client.gui.screen.CommandSuggestor;
 import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.server.command.CommandSource;
+import net.minecraft.command.CommandSource;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/src/main/kotlin/me/zeroeightsix/kami/KamiMod.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/KamiMod.kt
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.LogManager
 class KamiMod : ModInitializer {
     companion object {
         const val MODNAME = "KAMI"
-        const val MODVER = "fabric-1.16.3-debug"
+        const val MODVER = "fabric-1.16.4-debug"
         const val KAMI_KANJI = "\u795E"
 
         @JvmStatic

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/BindCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/BindCommand.kt
@@ -6,7 +6,7 @@ import me.zeroeightsix.kami.feature.FullFeature
 import me.zeroeightsix.kami.feature.HasBind
 import me.zeroeightsix.kami.util.Bind
 import me.zeroeightsix.kami.util.text
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.util.Formatting.GOLD
 import net.minecraft.util.Formatting.LIGHT_PURPLE
 import net.minecraft.util.Formatting.YELLOW

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/Command.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/Command.kt
@@ -6,7 +6,7 @@ import me.zeroeightsix.kami.KamiMod
 import me.zeroeightsix.kami.feature.Feature
 import me.zeroeightsix.kami.feature.FindFeature
 import me.zeroeightsix.kami.mc
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import net.minecraft.text.MutableText
 import java.util.regex.Pattern

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/ConfigCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/ConfigCommand.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
 import me.zeroeightsix.kami.setting.KamiConfig
 import me.zeroeightsix.kami.util.text
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import net.minecraft.util.Formatting.GOLD
 import net.minecraft.util.Formatting.YELLOW

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/FeatureArgumentType.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/FeatureArgumentType.kt
@@ -10,7 +10,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import me.zeroeightsix.kami.feature.FeatureManager.features
 import me.zeroeightsix.kami.feature.FullFeature
 import me.zeroeightsix.kami.feature.HasBind
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import java.util.NoSuchElementException
 import java.util.concurrent.CompletableFuture

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/FriendCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/FriendCommand.kt
@@ -12,7 +12,7 @@ import me.zeroeightsix.kami.util.text
 import net.minecraft.client.network.PlayerListEntry
 import net.minecraft.command.EntitySelector
 import net.minecraft.command.argument.EntityArgumentType
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import net.minecraft.text.MutableText
 import net.minecraft.util.Formatting.GOLD

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/PeekCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/PeekCommand.kt
@@ -16,7 +16,7 @@ import net.minecraft.block.entity.ShulkerBoxBlockEntity
 import net.minecraft.client.gui.screen.ingame.ShulkerBoxScreen
 import net.minecraft.item.BlockItem
 import net.minecraft.screen.ShulkerBoxScreenHandler
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import net.minecraft.util.Formatting.RED
 

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/PluginArgumentType.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/PluginArgumentType.kt
@@ -9,7 +9,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import me.zeroeightsix.kami.feature.FeatureManager
 import me.zeroeightsix.kami.feature.FeatureManager.getByName
 import me.zeroeightsix.kami.feature.plugin.Plugin
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import java.util.concurrent.CompletableFuture
 import java.util.function.Function

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/PluginCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/PluginCommand.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
 import me.zeroeightsix.kami.feature.plugin.Plugin
 import me.zeroeightsix.kami.util.text
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import net.minecraft.util.Formatting.GOLD
 import net.minecraft.util.Formatting.YELLOW

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/SayCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/SayCommand.kt
@@ -2,7 +2,7 @@ package me.zeroeightsix.kami.feature.command
 
 import com.mojang.brigadier.CommandDispatcher
 import me.zeroeightsix.kami.mc
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 
 object SayCommand : Command() {
     override fun register(dispatcher: CommandDispatcher<CommandSource>) {

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/SettingArgumentType.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/SettingArgumentType.kt
@@ -13,7 +13,7 @@ import io.github.fablabsmc.fablabs.api.fiber.v1.tree.ConfigNode
 import me.zeroeightsix.kami.feature.FullFeature
 import me.zeroeightsix.kami.flattenedStream
 import me.zeroeightsix.kami.setting.visibilityType
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import java.util.concurrent.CompletableFuture
 import java.util.function.Function

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/SettingsCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/SettingsCommand.kt
@@ -16,7 +16,7 @@ import me.zeroeightsix.kami.setting.getAnyRuntimeConfigType
 import me.zeroeightsix.kami.setting.settingInterface
 import me.zeroeightsix.kami.setting.visibilityType
 import me.zeroeightsix.kami.util.text
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.text.LiteralText
 import net.minecraft.text.Text
 import net.minecraft.util.Formatting.GOLD

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/ToggleCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/ToggleCommand.kt
@@ -3,7 +3,7 @@ package me.zeroeightsix.kami.feature.command
 import com.mojang.brigadier.CommandDispatcher
 import me.zeroeightsix.kami.feature.FullFeature
 import me.zeroeightsix.kami.util.text
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.util.Formatting
 import net.minecraft.util.Formatting.GOLD
 import net.minecraft.util.Formatting.YELLOW

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/command/VClipCommand.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/command/VClipCommand.kt
@@ -2,7 +2,7 @@ package me.zeroeightsix.kami.feature.command
 
 import com.mojang.brigadier.CommandDispatcher
 import me.zeroeightsix.kami.mc
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 
 object VClipCommand : Command() {
     override fun register(dispatcher: CommandDispatcher<CommandSource>) {

--- a/src/main/kotlin/me/zeroeightsix/kami/feature/module/Nametags.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/feature/module/Nametags.kt
@@ -236,8 +236,8 @@ object Nametags : Module() {
 
                 val immediate = mc.bufferBuilders.entityVertexConsumers
 
-                mc.textureManager.bindTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEX)
-                mc.textureManager.getTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEX)!!.setFilter(false, false)
+                mc.textureManager.bindTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)
+                mc.textureManager.getTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)!!.setFilter(false, false)
 
                 RenderSystem.enableRescaleNormal()
                 RenderSystem.enableAlphaTest()

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/widgets/InventoryPinnableWidget.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/widgets/InventoryPinnableWidget.kt
@@ -41,8 +41,8 @@ class InventoryPinnableWidget(
                 KamiHud.postDraw {
                     val scale = KamiHud.getScale()
 
-                    mc.textureManager.bindTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEX)
-                    mc.textureManager.getTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEX)!!.setFilter(false, false)
+                    mc.textureManager.bindTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)
+                    mc.textureManager.getTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE)!!.setFilter(false, false)
 
                     RenderSystem.enableRescaleNormal()
                     RenderSystem.enableAlphaTest()

--- a/src/main/kotlin/me/zeroeightsix/kami/setting/KamiConfig.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/setting/KamiConfig.kt
@@ -54,7 +54,7 @@ import me.zeroeightsix.kami.unsignedInt
 import me.zeroeightsix.kami.util.Bind
 import me.zeroeightsix.kami.util.Friends
 import net.minecraft.client.util.InputUtil
-import net.minecraft.server.command.CommandSource
+import net.minecraft.command.CommandSource
 import net.minecraft.util.Identifier
 import org.reflections.Reflections
 import uno.kotlin.NUL

--- a/src/main/kotlin/me/zeroeightsix/kami/world/KamiRenderLayers.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/world/KamiRenderLayers.kt
@@ -5,7 +5,6 @@ import net.minecraft.client.MinecraftClient.IS_SYSTEM_MAC
 import net.minecraft.client.gl.Framebuffer
 import net.minecraft.client.render.RenderLayer
 import net.minecraft.client.render.RenderPhase
-import net.minecraft.client.render.VertexFormat
 import net.minecraft.client.render.VertexFormats
 import net.minecraft.client.texture.SpriteAtlasTexture
 import org.lwjgl.opengl.GL11
@@ -13,7 +12,7 @@ import org.lwjgl.opengl.GL11
 object KamiRenderLayers {
     private val smoothModel = RenderPhase.ShadeModel(true)
     private val disableLightmap = RenderPhase.Lightmap(false)
-    private val mipmapTexture = RenderPhase.Texture(SpriteAtlasTexture.BLOCK_ATLAS_TEX, false, true)
+    private val mipmapTexture = RenderPhase.Texture(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE, false, true)
 
     @Suppress("INACCESSIBLE_TYPE")
     val solidFiltered: RenderLayer = RenderLayer.of(

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
 
   "depends": {
     "fabricloader": ">=0.4.0",
-    "minecraft": "1.16.3"
+    "minecraft": "1.16.4"
   },
   "suggests": {
     "fabritone": ">=1.6.2"


### PR DESCRIPTION
Note: `SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE` is now marked as deprecated now (used in Nametags, KamiRenderLayers, and InventoryPinnableWidget)

![](https://media.discordapp.net/attachments/496724197121196033/772934807243849788/Screenshot_20201102_162629.png)