### PR TITLE
ESP: resolve issue with rendering backedModels that do not have a direction.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinRebuildTask.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinRebuildTask.java
@@ -116,6 +116,14 @@ public class MixinRebuildTask {
             }
         }
 
+        random.setSeed(seed);
+
+        List<BakedQuad> list2 = bakedModel.getQuads(blockState, null, random);
+        if (!list2.isEmpty()) {
+            renderQuadsFlatUnlit(manager, blockRenderView, blockState, blockPos, -1, OverlayTexture.DEFAULT_UV, matrixStack, vertexConsumer, list2);
+            ret = true;
+        }
+
         return ret;
     }
 

--- a/src/main/kotlin/me/zeroeightsix/kami/target/CategorisedTargets.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/target/CategorisedTargets.kt
@@ -11,6 +11,7 @@ import me.zeroeightsix.kami.util.ResettableLazy
 import net.minecraft.block.Block
 import net.minecraft.block.Fertilizable
 import net.minecraft.block.Material
+import net.minecraft.block.NetherPortalBlock
 import net.minecraft.block.OreBlock
 import net.minecraft.block.SlabBlock
 import net.minecraft.block.Waterloggable
@@ -127,6 +128,7 @@ enum class BlockEntityCategory(
 enum class BlockCategory(override val belongsFunc: (Block) -> Boolean) : CategorisedTargetProvider<Block> {
     NONE({ false }),
     ORES({ it is OreBlock }),
+    NETHER_PORTAL({ it is NetherPortalBlock }),
     SLABS({ it is SlabBlock }),
     FERTILIZABLE({ it is Fertilizable }),
     WATERLOGGABLE({ it is Waterloggable });


### PR DESCRIPTION
Some BakedModels only render when the direction is null. This is the case for Nether Portals, Fire, etc...

This is done in the same way that render{Smooth,Flat} in BlockModelRenderer excluding the light calculations.

End Portals use a different rendering technique that still needs to be resolved to get it to work.