### PR TITLE
chore: bump imgui, fabritone, and JVM targets

### DIFF
--- a/.github/workflows/fabricmod.yml
+++ b/.github/workflows/fabricmod.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/checkout@v2
       
       # Set up the compiler
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,13 +12,13 @@ val maven_group: String by project
 plugins {
     id("fabric-loom")
     id("maven-publish")
-    id("com.github.johnrengelman.shadow") version "5.2.0"
+    id("com.github.johnrengelman.shadow") version "6.1.0"
     kotlin("jvm")
 }
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 version = "$minecraft_version-$mod_version"
@@ -82,7 +82,12 @@ dependencies {
     includedModImpl("net.fabricmc.fabric-api:fabric-api-base:0.1.3+12a8474cfa")
     includedModImpl("net.fabricmc.fabric-api:fabric-resource-loader-v0:0.2.9+e5d3217f4e")
     includedModImpl("com.github.Ladysnake:Satin:1.5.0")
-    modImplementation("com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT")
+    modImplementation("com.gitlab.CDAGaming:fabritone:fabric~1.16.3-SNAPSHOT") {
+        exclude(group = "org.lwjgl.lwjgl")
+        exclude(group= "net.java.jinput")
+        exclude(group= "net.sf.jopt-simple")
+        exclude(group= "org.ow2.asm")
+    }
 
     depend(INCLUDE, "com.github.fablabsmc:fiber:$fiber_version")
     depend(INCLUDE, "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
@@ -132,7 +137,7 @@ tasks {
 
     withType(KotlinCompile::class) {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = "11"
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,11 +82,13 @@ dependencies {
     includedModImpl("net.fabricmc.fabric-api:fabric-api-base:0.1.3+12a8474cfa")
     includedModImpl("net.fabricmc.fabric-api:fabric-resource-loader-v0:0.2.9+e5d3217f4e")
     includedModImpl("com.github.Ladysnake:Satin:1.5.0")
+    
+    // 1.16.4+ has not added any additional functionality and 1.16.3 Fabritone will work on newer versions.
     modImplementation("com.gitlab.CDAGaming:fabritone:fabric~1.16.3-SNAPSHOT") {
         exclude(group = "org.lwjgl.lwjgl")
-        exclude(group= "net.java.jinput")
-        exclude(group= "net.sf.jopt-simple")
-        exclude(group= "org.ow2.asm")
+        exclude(group = "net.java.jinput")
+        exclude(group = "net.sf.jopt-simple")
+        exclude(group = "org.ow2.asm")
     }
 
     depend(INCLUDE, "com.github.fablabsmc:fiber:$fiber_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,20 +4,20 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx3G
 # Fabric
 minecraft_version=1.16.4
-yarn_mappings=1.16.4+build.1:v2
-loader_version=0.9.3+build.207
-loom_version=0.5-SNAPSHOT
+yarn_mappings=1.16.4+build.9
+loader_version=0.11.1
+loom_version=0.6-SNAPSHOT
 # KAMI
 mod_version=dec
 maven_group=me.zeroeightsix
 archives_base_name=kami
 # Dependencies
-kotlin_version=1.4.0
+kotlin_version=1.4.21
 fiber_version=fix~undetected-mutation-SNAPSHOT
-kg_version=4e5eec4af9
-unsigned_version=1a71e303
-kool_version=4359096c
-glm_version=557908c3
-gli_version=4c290e0d
-gln_version=2c26a366
-uno_version=2599943c
+kg_version=7347a5d238
+unsigned_version=1e2fda82
+kool_version=b393e4c2
+glm_version=a4185eec
+gli_version=9c67885f
+gln_version=3e59f9ea
+uno_version=f60532b7

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiHud.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiHud.kt
@@ -47,6 +47,8 @@ object KamiHud {
             ImGui.io.fonts.addFontFromMemoryTTF(chars, sizePixels, fontCfg, arrayOf())
         }
 
+        imgui.DEBUG = false
+
         val window = GlfwWindow.from(mc.window.handle)
         window.makeContextCurrent()
         context = Context()

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiHud.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiHud.kt
@@ -17,13 +17,11 @@ import me.zeroeightsix.kami.gui.windows.Settings
 import me.zeroeightsix.kami.mc
 import me.zeroeightsix.kami.tempSet
 import me.zeroeightsix.kami.tryOrNull
-import me.zeroeightsix.kami.util.Wrapper
 import net.minecraft.client.util.math.MatrixStack
 import uno.glfw.GlfwWindow
-import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.Stack
+import java.util.*
 
 object KamiHud {
 

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/windows/modules/Modules.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/windows/modules/Modules.kt
@@ -7,7 +7,7 @@ import imgui.ImGui.acceptDragDropPayload
 import imgui.ImGui.collapsingHeader
 import imgui.ImGui.currentWindow
 import imgui.ImGui.isItemClicked
-import imgui.ImGui.openPopupContextItem
+import imgui.ImGui.openPopupOnItemClick
 import imgui.ImGui.selectable
 import imgui.ImGui.treeNodeBehaviorIsOpen
 import imgui.ImGui.treeNodeEx
@@ -97,7 +97,7 @@ object Modules {
             if (selectable(module.name, module.enabled)) {
                 module.enabled = !module.enabled
             }
-            openPopupContextItem("module-settings-${module.name}", MouseButton.Right.i)
+            openPopupOnItemClick("module-settings-${module.name}", MouseButton.Right.i)
             popup("module-settings-${module.name}") {
                 showModuleSettings(module)
             }

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/windows/modules/Modules.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/windows/modules/Modules.kt
@@ -270,7 +270,7 @@ private fun showModuleSettings(module: Module) {
 
     if (!Settings.hideModuleDescriptions) {
         ImGui.pushStyleColor(Col.Text, Vec4(.7f, .7f, .7f, 1f))
-        ImGui.text("%s", module.description)
+        ImGui.text(module.description)
         ImGui.popStyleColor()
     }
 

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/wizard/Wizard.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/wizard/Wizard.kt
@@ -57,7 +57,7 @@ object Wizard {
             Settings.showFontSelector("Font###kami-settings-font-selector")
 
             pushStyleColor(Col.Text, Vec4(.7f, .7f, .7f, 1f))
-            text("%s", "GUI is visible in the background")
+            text("GUI is visible in the background")
             popStyleColor()
 
             KamiGuiScreen.renderGui() // Show the full GUI
@@ -75,11 +75,8 @@ object Wizard {
             }
 
             pushStyleColor(Col.Text, Vec4(.7f, .7f, .7f, 1f))
-            textWrapped(
-                "%s",
-                "The module windows in KAMI are fully customizable. If neither choice appeals to you, you can manually reorganise the module windows through the module window editor."
-            )
-            textWrapped("%s", "The module window editor may be accessed through the `View` menu in the top menu bar.")
+            textWrapped("The module windows in KAMI are fully customizable. If neither choice appeals to you, you can manually reorganise the module windows through the module window editor.")
+            textWrapped("The module window editor may be accessed through the `View` menu in the top menu bar.")
             popStyleColor()
         },
         {
@@ -111,19 +108,21 @@ object Wizard {
             pushStyleColor(Col.Text, Vec4(.7f, .7f, .7f, 1f))
             val leftToggle = Settings.openSettingsInPopup || Settings.swapModuleListButtons
             text(
-                "%s-click to toggle, %s-click to open settings.",
-                if (leftToggle) {
-                    "Left"
-                } else {
-                    "Right"
-                },
-                if (!leftToggle) {
-                    "left"
-                } else {
-                    "right"
-                }
+                "${
+                    if (leftToggle) {
+                        "Left"
+                    } else {
+                        "Right"
+                    }
+                }-click to toggle, ${
+                    if (!leftToggle) {
+                        "left"
+                    } else {
+                        "right"
+                    }
+                }-click to open settings.",
             )
-            text("%s", "Try it out:")
+            text("Try it out:")
             popStyleColor()
 
             Modules.module(Aura, Modules.ModuleWindow("", Aura), "")
@@ -139,15 +138,15 @@ object Wizard {
             separator()
 
             pushStyleColor(Col.Text, Vec4(.7f, .7f, .7f, 1f))
-            text("%s", "Assuming 'K' is bound to Aura,")
-            text("%s", "And 'CTRL+Q' is bound to Brightness,")
+            text("Assuming 'K' is bound to Aura,")
+            text("And 'CTRL+Q' is bound to Brightness,")
             dummy(Vec2(10))
             val not = if (Settings.modifiersEnabled) " NOT " else " "
-            text("%s", "Pressing K WILL toggle Aura.")
-            text("%s", "Pressing SHIFT+K WILL${not}toggle Aura.")
+            text("Pressing K WILL toggle Aura.")
+            text("Pressing SHIFT+K WILL${not}toggle Aura.")
             dummy(Vec2(10))
-            text("%s", "Pressing CTRL+Q WILL toggle Brightness.")
-            text("%s", "Pressing Q WILL${not}toggle Brightness.")
+            text("Pressing CTRL+Q WILL toggle Brightness.")
+            text("Pressing Q WILL${not}toggle Brightness.")
             popStyleColor()
 
             separator()

--- a/src/main/resources/kami.mixins.json
+++ b/src/main/resources/kami.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_11",
   "package": "me.zeroeightsix.kami.mixin.client",
   "client": [
     "IBackedConfigLeaf",


### PR DESCRIPTION
kotlin-graphics has had a few bugs fixed that have shown up in my usage.

* Sliders would not change when manually entered a number
* Drop-down menus would not function without the layout shuffling sometimes.

Bumping the dependencies resolved the issues that I was having.

While we are here, bump Fabritone to fix the CI build.

Integration is untested, but working on some Baritone experiments.

I haven't bump this to 1.16.5 just yet even though it should just work as it's mostly server stability fixes.