### PR TITLE
Removed unecessary return in NoPacketKick mixin

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinClientConnection.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinClientConnection.java
@@ -46,7 +46,6 @@ public class MixinClientConnection {
     @Inject(method = "exceptionCaught", at = @At("HEAD"), cancellable = true)
     private void exceptionCaught(ChannelHandlerContext context, Throwable throwable, CallbackInfo ci) {
         if (throwable instanceof IOException && NoPacketKick.INSTANCE.getEnabled()) ci.cancel();
-        return;
     }
 
 }


### PR DESCRIPTION
CallbackInfo is already cancelled, it shouldn't run the code after. And you shouldn't be injecting return to cancel stuff anyways