### PR TITLE
[fix] update kami.mixins.json to use JAVA_8 compatibilityLevel

### DIFF
--- a/src/main/resources/kami.mixins.json
+++ b/src/main/resources/kami.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "compatibilityLevel": "JAVA_11",
+  "compatibilityLevel": "JAVA_8",
   "package": "me.zeroeightsix.kami.mixin.client",
   "client": [
     "IBackedConfigLeaf",


### PR DESCRIPTION
We failed to revert this specific change when we reverted back to Java 8 thanks to the imgui-java port.