### PR TITLE
fix: temporarily fix closing an open meta tree and then returning

### DIFF
--- a/src/main/kotlin/me/zeroeightsix/kami/target/TargetSupplier.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/target/TargetSupplier.kt
@@ -296,6 +296,7 @@ inline fun <M, B, reified E : Enum<E>, reified S : TargetSupplier.SpecificTarget
                             if (!isSingleton && sameLine().run { smallButton("-") }) {
                                 // Return null. `mapNotNull` will omit entries from the map that returned null.
                                 dirty = true
+                                if (nodeOpen) treePop()
                                 return@mapNotNull null
                             }
 
@@ -366,6 +367,7 @@ inline fun <M, B, reified E : Enum<E>, reified S : TargetSupplier.SpecificTarget
                                 if (!isSingleton && sameLine().run { smallButton("-") }) {
                                     // Return null. `mapNotNull` will omit entries from the map that returned null.
                                     dirty = true
+                                    if (nodeOpen) treePop()
                                     return@mapNotNull null
                                 }
 


### PR DESCRIPTION
We should redo this by creating a withTreeNode that's optional here to avoid this.