### PR TITLE
[fix] Force initialise ImGui in the MinecraftClient constructor at return

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraftClient.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraftClient.java
@@ -3,6 +3,7 @@ package me.zeroeightsix.kami.mixin.client;
 import me.zeroeightsix.kami.KamiMod;
 import me.zeroeightsix.kami.event.ScreenEvent;
 import me.zeroeightsix.kami.event.TickEvent;
+import me.zeroeightsix.kami.gui.KamiImgui;
 import me.zeroeightsix.kami.setting.KamiConfig;
 import me.zeroeightsix.kami.util.Wrapper;
 import net.minecraft.client.MinecraftClient;
@@ -10,6 +11,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.profiler.Profiler;
+import org.apache.logging.log4j.LogManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -30,6 +32,12 @@ public class MixinMinecraftClient {
 
     @Shadow
     private Profiler profiler;
+
+    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    public void init(CallbackInfo info) {
+        KamiImgui.INSTANCE.init();
+        LogManager.getLogger("KAMI").info("ImGui initialised.");
+    }
 
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;pop()V", ordinal = 0, shift = At.Shift.AFTER), cancellable = true)
     public void tick(CallbackInfo info) {

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
@@ -92,22 +92,11 @@ object KamiImgui {
         val defaultFontName = fontNames.getOrElse(Settings.font) { fontNames.first() }
         ImGui.getIO().setFontDefault(fonts[defaultFontName])
 
-        val caps = GL.getCapabilities()
-        // TODO: check if this works on macOS properly.
-        val glslVersion = when {
-            caps.OpenGL32 -> {
-                150
-            }
-            caps.OpenGL30 -> { // apparently we might have to skip this one?
-                130
-            }
-            else -> 110
-        }
-
         ImGui.getIO().addConfigFlags(ImGuiConfigFlags.DockingEnable)
 
         imguiGlfw.init(mc.window.handle, false)
-        imguiGl.init("#version $glslVersion")
+        // Force 110 shaders since this is what base Minecraft uses to avoid bugs in Intel drivers.
+        imguiGl.init("#version 110")
     }
 
     internal fun frame(matrices: MatrixStack, block: () -> Unit) {

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
@@ -36,8 +36,10 @@ object KamiImgui {
     private const val minecraftiaLocation = "/assets/kami/Minecraftia.ttf"
 
     fun init() {
-        fun addKamiFontFromTTF(filename: String, sizePixels: Float, fontCfg: ImFontConfig): ImFont? {
-            val bytes = ByteStreams.toByteArray(javaClass.getResourceAsStream(filename) ?: return null)
+        fun loadFontFromResources(filename: String): ByteArray? {
+            return ByteStreams.toByteArray(javaClass.getResourceAsStream(filename) ?: return null)
+        }
+        fun addKamiFontFromTTF(bytes: ByteArray, sizePixels: Float, fontCfg: ImFontConfig): ImFont? {
             return ImGui.getIO().fonts.addFontFromMemoryTTF(bytes, sizePixels, fontCfg)
         }
 
@@ -55,28 +57,31 @@ object KamiImgui {
             return fontCfg
         }
 
-        addKamiFontFromTTF(
-            minecraftiaLocation,
-            12f,
-            fontCfg {
-                oversampleH = 1
-                oversampleV = 1
-                pixelSnapH = true
+        loadFontFromResources(minecraftiaLocation)?.let { bytes ->
+            addKamiFontFromTTF(
+                bytes,
+                12f,
+                fontCfg {
+                    oversampleH = 1
+                    oversampleV = 1
+                    pixelSnapH = true
+                }
+            )?.let {
+                fonts.put("Minecraftia 12px", it)
             }
-        )?.let {
-            fonts.put("Minecraftia 12px", it)
-        }
-        addKamiFontFromTTF(
-            minecraftiaLocation,
-            24f,
-            fontCfg {
-                oversampleH = 1
-                oversampleV = 1
-                pixelSnapH = true
+            addKamiFontFromTTF(
+                bytes,
+                24f,
+                fontCfg {
+                    oversampleH = 1
+                    oversampleV = 1
+                    pixelSnapH = true
+                }
+            )?.let {
+                fonts.put("Minecraftia 24px", it)
             }
-        )?.let {
-            fonts.put("Minecraftia 24px", it)
         }
+
         ImGui.getIO().fonts.addFontDefault()?.let {
             fonts.put("Default", it)
         }

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
@@ -35,7 +35,7 @@ object KamiImgui {
 
     private const val minecraftiaLocation = "/assets/kami/Minecraftia.ttf"
 
-    init {
+    fun init() {
         fun addKamiFontFromTTF(filename: String, sizePixels: Float, fontCfg: ImFontConfig): ImFont? {
             val bytes = ByteStreams.toByteArray(javaClass.getResourceAsStream(filename) ?: return null)
             return ImGui.getIO().fonts.addFontFromMemoryTTF(bytes, sizePixels, fontCfg)


### PR DESCRIPTION
This will force init ImGui during the MinecraftClient constructor and avoid any odd concurrent state changes or texture pipeline oddities since nothing is being used yet.

This is the most minimally invasive spot; otherwise, we will need to inject into the end of the Window constructor if we want the closest point we can constructor the ImGui contexts.
 
Closes #533