### PR TITLE
[feature] Adjustable font size

### DIFF
--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
@@ -31,7 +31,7 @@ object KamiImgui {
     private const val INI_FILENAME = "kami-imgui.ini"
 
     val fonts = mutableMapOf<String, ImFont>()
-    val fontNames = arrayOf("Minecraftia 12px", "Minecraftia 24px", "Default")
+    val fontNames = arrayOf("Minecraftia", "Default")
 
     private const val minecraftiaLocation = "/assets/kami/Minecraftia.ttf"
 
@@ -60,25 +60,14 @@ object KamiImgui {
         loadFontFromResources(minecraftiaLocation)?.let { bytes ->
             addKamiFontFromTTF(
                 bytes,
-                12f,
+                Settings.fontSize,
                 fontCfg {
                     oversampleH = 1
                     oversampleV = 1
                     pixelSnapH = true
                 }
             )?.let {
-                fonts.put("Minecraftia 12px", it)
-            }
-            addKamiFontFromTTF(
-                bytes,
-                24f,
-                fontCfg {
-                    oversampleH = 1
-                    oversampleV = 1
-                    pixelSnapH = true
-                }
-            )?.let {
-                fonts.put("Minecraftia 24px", it)
+                fonts.put("Minecraftia", it)
             }
         }
 

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/KamiImgui.kt
@@ -16,7 +16,6 @@ import me.zeroeightsix.kami.mc
 import me.zeroeightsix.kami.tryOrNull
 import me.zeroeightsix.kami.util.Bind
 import net.minecraft.client.util.math.MatrixStack
-import org.lwjgl.opengl.GL
 
 object KamiImgui {
 

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/windows/Settings.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/windows/Settings.kt
@@ -6,6 +6,7 @@ import imgui.ImGui.colorConvertHSVtoRGB
 import imgui.ImGui.colorConvertRGBtoHSV
 import imgui.ImGui.colorEdit3
 import imgui.ImGui.dragFloat
+import imgui.ImGui.dragInt
 import imgui.ImGui.dummy
 import imgui.ImGui.popID
 import imgui.ImGui.pushID
@@ -25,6 +26,7 @@ import me.zeroeightsix.kami.gui.ImguiDSL.tabBar
 import me.zeroeightsix.kami.gui.ImguiDSL.tabItem
 import me.zeroeightsix.kami.gui.ImguiDSL.window
 import me.zeroeightsix.kami.gui.ImguiDSL.wrapSingleFloatArray
+import me.zeroeightsix.kami.gui.ImguiDSL.wrapSingleIntArray
 import me.zeroeightsix.kami.gui.KamiImgui
 import me.zeroeightsix.kami.gui.Themes
 import me.zeroeightsix.kami.gui.charButton
@@ -66,6 +68,9 @@ object Settings {
     // Appearance
     @Setting
     var font: Int = 0
+
+    @Setting
+    var fontSize = 12f
 
     @Setting
     var rainbowMode = false
@@ -170,6 +175,8 @@ object Settings {
                     tabItem("Appearance") {
                         showFontSelector()
 
+                        showFontSizeSlider()
+
                         showThemeSelector()
 
                         KamiConfig.alignmentType.settingInterface?.displayImGui(
@@ -237,6 +244,19 @@ object Settings {
                 label,
                 it,
                 0.1f,
+                0f,
+                50f,
+                "%.0f"
+            )
+        }
+    }
+
+    fun showFontSizeSlider(label: String = "Font size") {
+        wrapSingleFloatArray(::fontSize) {
+            dragFloat(
+                label,
+                it,
+                1f,
                 0f,
                 50f,
                 "%.0f"

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/windows/Settings.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/windows/Settings.kt
@@ -6,7 +6,6 @@ import imgui.ImGui.colorConvertHSVtoRGB
 import imgui.ImGui.colorConvertRGBtoHSV
 import imgui.ImGui.colorEdit3
 import imgui.ImGui.dragFloat
-import imgui.ImGui.dragInt
 import imgui.ImGui.dummy
 import imgui.ImGui.popID
 import imgui.ImGui.pushID
@@ -26,7 +25,6 @@ import me.zeroeightsix.kami.gui.ImguiDSL.tabBar
 import me.zeroeightsix.kami.gui.ImguiDSL.tabItem
 import me.zeroeightsix.kami.gui.ImguiDSL.window
 import me.zeroeightsix.kami.gui.ImguiDSL.wrapSingleFloatArray
-import me.zeroeightsix.kami.gui.ImguiDSL.wrapSingleIntArray
 import me.zeroeightsix.kami.gui.KamiImgui
 import me.zeroeightsix.kami.gui.Themes
 import me.zeroeightsix.kami.gui.charButton

--- a/src/main/kotlin/me/zeroeightsix/kami/gui/wizard/Wizard.kt
+++ b/src/main/kotlin/me/zeroeightsix/kami/gui/wizard/Wizard.kt
@@ -139,6 +139,7 @@ object Wizard {
         text("Please select your preferred theme and font.")
         Settings.showThemeSelector()
         Settings.showFontSelector()
+        Settings.showFontSizeSlider()
 
         pushStyleColor(ImGuiCol.Text, .7f, .7f, .7f, 1f)
         text("GUI is visible in the background")


### PR DESCRIPTION
Adds a font size slider instead of having hardcoded font sizes and redundant fonts in selector.

Also size 24 is way to small for 4k displays. Thats why i added this in the first place.

Current problem: Font needs to get updated when slider gets changed. Dont know how to do that yet. Help apprechiated.

Also: I cant login with my mc account in IDE and need to build it then put it into MultiMC and run it from there. Also i need to close IntelliJ all the time when i do a new build bc i cant delete the last build jar bc its opened in Java wtf

```* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':remapJar'.
Caused by: java.nio.file.FileSystemException: C:\Users\Christian\Documents\GitKraken\KAMI\build\libs\KAMI-1.16.5-feb.jar: Der Prozess kann nicht auf die Datei zugreifen, da sie von einem anderen Prozess verwendet wird.

	at com.sun.nio.zipfs.ZipFileSystem.sync(ZipFileSystem.java:1312)
	at com.sun.nio.zipfs.ZipFileSystem.close(ZipFileSystem.java:277)
	at net.fabricmc.tinyremapper.OutputConsumerPath.close(OutputConsumerPath.java:317)
	at net.fabricmc.loom.task.RemapJarTask.doSingleRemap(RemapJarTask.java:136)
	... 121 more
```